### PR TITLE
修改聊天时无法显示后端返回的消息

### DIFF
--- a/.idea/data_source_mapping.xml
+++ b/.idea/data_source_mapping.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="DataSourcePerFileMappings">
-    <file url="file://$APPLICATION_CONFIG_DIR$/consoles/db/f5ccdca4-bdbb-42f9-a420-102347009286/console.sql" value="f5ccdca4-bdbb-42f9-a420-102347009286" />
-  </component>
-</project>

--- a/src/components/ChatRoom/SSEHandler.ts
+++ b/src/components/ChatRoom/SSEHandler.ts
@@ -1,5 +1,5 @@
 import { fetchEventSource } from '@microsoft/fetch-event-source';
-import { TokenManager } from '../../utils/request';
+import { TokenManager } from '@/utils/request';
 import AiChatService from '../../services/aiChatService';
 
 export interface SSEMessage {
@@ -282,9 +282,14 @@ export class SSEHandler {
         console.log('⚠️ 收到空数据，跳过处理');
         return null;
       }
-
+      // console.log("rawData: ====> ", rawData);
+      const jsonStr = rawData.replace(/^data:\s*/, '').trim();
+      if (jsonStr === '[DONE]') {
+          this.finishProcessing();
+          return null;
+      }
       // 解析JSON数据
-      const data = JSON.parse(rawData);
+      const data = JSON.parse(jsonStr);
       console.log('📊 解析后的数据:', data);
 
       // 处理choices[0].delta.content格式


### PR DESCRIPTION
后端返回SSE时，消息头中有一个data标签，在前端无法直接把返回的消息进行json转换，在`SSEHandler.ts`中添加了几行代码：
```typescript
const jsonStr = rawData.replace(/^data:\s*/, '').trim();
if (jsonStr === '[DONE]') {
    this.finishProcessing();
    return null;
}
```